### PR TITLE
Add sailing, block its minExp check for now

### DIFF
--- a/src/main/java/com/duckblade/runelite/togindicator/TOGIndicatorOverlay.java
+++ b/src/main/java/com/duckblade/runelite/togindicator/TOGIndicatorOverlay.java
@@ -13,7 +13,6 @@ import net.runelite.api.Skill;
 import net.runelite.api.gameval.InterfaceID;
 import net.runelite.api.widgets.JavaScriptCallback;
 import net.runelite.api.widgets.Widget;
-import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -80,7 +79,7 @@ public class TOGIndicatorOverlay extends Overlay
 		{
 			int skillExp = client.getSkillExperience(s);
 			// Remove the sailing block when Jagex allows Tears to be put into the skill.
-			if (skillExp < minExp && !s.getName().equals("Sailing"))
+			if (skillExp < minExp && s != Skill.SAILING)
 			{
 				minExp = skillExp;
 			}


### PR DESCRIPTION
Fixed to add the Sailing skill, but also skips it from the min check since Tears won't work with it for a while.

Closes #3