### PR TITLE
Enable Sailing

### DIFF
--- a/src/main/java/com/duckblade/runelite/togindicator/TOGIndicatorOverlay.java
+++ b/src/main/java/com/duckblade/runelite/togindicator/TOGIndicatorOverlay.java
@@ -78,8 +78,8 @@ public class TOGIndicatorOverlay extends Overlay
 		for (Skill s : Skill.values())
 		{
 			int skillExp = client.getSkillExperience(s);
-			// Remove the sailing block when Jagex allows Tears to be put into the skill.
-			if (skillExp < minExp && s != Skill.SAILING)
+			
+			if (skillExp < minExp)
 			{
 				minExp = skillExp;
 			}

--- a/src/main/java/com/duckblade/runelite/togindicator/TOGIndicatorOverlay.java
+++ b/src/main/java/com/duckblade/runelite/togindicator/TOGIndicatorOverlay.java
@@ -78,7 +78,6 @@ public class TOGIndicatorOverlay extends Overlay
 		for (Skill s : Skill.values())
 		{
 			int skillExp = client.getSkillExperience(s);
-			
 			if (skillExp < minExp)
 			{
 				minExp = skillExp;


### PR DESCRIPTION
Remove block that disables Sailing. As of 12/3/2025, ToG rewards can be used on Sailing. 